### PR TITLE
Fixed labelStyle.

### DIFF
--- a/lib/shifting_tabbar.dart
+++ b/lib/shifting_tabbar.dart
@@ -217,7 +217,7 @@ class _ShiftingTabWidget extends AnimatedWidget {
           animation, 
           color, 
           dir, 
-          labelStyle ?? Theme.of(context).textTheme.headline.copyWith(fontSize: 14, color: color, letterSpacing: 2, fontWeight: FontWeight.bold)
+          labelStyle ?? Theme.of(context).textTheme.headline5.copyWith(fontSize: 14, color: color, letterSpacing: 2, fontWeight: FontWeight.bold)
         ),
       ],
     );


### PR DESCRIPTION
Flutter 1.17 deprecated ThemeData.textTheme.headline recently since version 1.13. Fixed it to the new style.